### PR TITLE
script_name изменен с url в его паттерн

### DIFF
--- a/src/Middlewares/RightUrlMiddleware.php
+++ b/src/Middlewares/RightUrlMiddleware.php
@@ -18,7 +18,7 @@ class RightUrlMiddleware
     public function handle($request, Closure $next)
     {
         $return = $next($request);
-        Pinba::setScriptName($request->getPathInfo());
+        Pinba::setScriptName($request->route()->uri);
         return $return;
     }
 }


### PR DESCRIPTION
В grafana заметили что script_name неправильно подставляется, вместо паттерна сам url: `/balance/merchants/-5/accounts`